### PR TITLE
-Add Constants.UserInfoType and expand Graph.GetMembers() and Graph.GetOwners()

### DIFF
--- a/Classes/Extensions.Constants.cs
+++ b/Classes/Extensions.Constants.cs
@@ -192,12 +192,13 @@ namespace Extensions
         public const double CB = ShB * 1024;
 
         /// <summary>
-        /// Number of bytes in a Koentekbyte.
+        /// Number of bytes in a Koentekbyte. *1024^81
         /// </summary>
         public const double KkB = CB * 1024;
 
         /// <summary>
-        /// Number of bytes in a CornelionByte.
+        /// Number of bytes in a CornelionByte. *1024^100000000
+        /// Cornelion = "1 x 10 ^ 100,000,000";
         /// </summary>
         public const string CornelionByte = "1 x 10 ^ 100,000,000";
         #endregion Binary Constants
@@ -206,11 +207,14 @@ namespace Extensions
         /// <summary>
         /// Enum of possible frequency in which interest compounding is done.
         /// </summary>
-        public enum CompoundFrequency { Monthly, Yearly };
+        public enum CompoundFrequency 
+        { 
+            Monthly, 
+            Yearly 
+        };
         #endregion CompoundFrequency
 
         #region Cryptography
-
         /// <summary>
         /// List of encryption providers to use.
         /// </summary>
@@ -228,21 +232,29 @@ namespace Extensions
             SHA512,
             TrippleDES
         }
-
         #endregion Cryptography
 
         #region EnumerationType
         /// <summary>
         /// Enum of possible enumerable types.
         /// </summary>
-        public enum EnumerableType { Dictionary, NameValueCollection };
+        public enum EnumerableType 
+        { 
+            Dictionary, 
+            NameValueCollection 
+        };
         #endregion EnumerationType
 
         #region ErrorType
         /// <summary>
         /// Enum of error types to validate.
         /// </summary>
-        public enum ErrorType { Null, IntNonNegative };
+        public enum ErrorType 
+        { 
+            Null, 
+            IntNonNegative 
+        };
+
         /// <summary>
         /// Array holding all error types for easier passing.
         /// </summary>
@@ -252,6 +264,18 @@ namespace Extensions
             ErrorType.IntNonNegative
         };
         #endregion ErrorType
+
+        #region Graph Constants
+        /// <summary>
+        /// The types of Graph user info to retrieve.
+        /// </summary>
+        public enum UserInfoType
+        {
+            id,
+            mail,
+            userProfileName
+        }
+        #endregion Graph Constants
 
         #region Help
         /// <summary>
@@ -318,7 +342,11 @@ namespace Extensions
         /// <summary>
         /// Enum of possible comparison types in the Mersenne type.
         /// </summary>
-        public enum MersenneComparisonType { Greater, Less };
+        public enum MersenneComparisonType 
+        { 
+            Greater, 
+            Less 
+        };
         #endregion Mersenne
 
         #region Morse
@@ -374,14 +402,25 @@ namespace Extensions
         /// <summary>
         /// Enum of possible quote types.
         /// </summary>
-        public enum QuoteType { Single, Double };
+        public enum QuoteType 
+        { 
+            Single, 
+            Double 
+        };
         #endregion Quote
 
         #region Substring
         /// <summary>
         /// List of processing options for .Substring() method.
         /// </summary>
-        public enum SubstringType { FromHead, FromTail, LeftOfIndex, RigthOfIndex, IndexValue };
+        public enum SubstringType 
+        { 
+            FromHead, 
+            FromTail, 
+            LeftOfIndex, 
+            RigthOfIndex, 
+            IndexValue 
+        };
         #endregion Substring
 
         #region TimeSpan

--- a/Classes/Extensions.Graph.cs
+++ b/Classes/Extensions.Graph.cs
@@ -453,9 +453,13 @@ namespace Extensions
         /// of a specified Group.
         /// </summary>
         /// <param name="groupId">The ID (GUID) of the target group.</param>
+        /// <param name="userInfoType">The type of user info to return
+        /// i.e. "id", "mail" or "userProfileName".  Default is "id".</param>
         /// <returns>A list of strings representing the IDs of member 
         /// users.</returns>
-        public static List<string> GetMembers(string groupId)
+        public static List<string> GetMembers(
+            string groupId, 
+            Constants.UserInfoType userInfoType = Constants.UserInfoType.id)
         {
             //Create the aggregation container.
             List<string> members = new List<string>();
@@ -464,7 +468,10 @@ namespace Extensions
             var usersPage = ActiveAuth.GraphClient.Groups[groupId]
                 .Members.GraphUser.GetAsync(C =>
                 {
-                    C.QueryParameters.Select = new string[] { "id" };
+                    C.QueryParameters.Select = new string[] 
+                    { 
+                        userInfoType.ToString() 
+                    };
                 }).GetAwaiter().GetResult();
             if (usersPage.Value.Count == 0)
             {
@@ -476,7 +483,30 @@ namespace Extensions
                     usersPage,
                     (user) =>
                     {
-                        members.Add(user.Id);
+                        switch (userInfoType)
+                        {
+                            case Constants.UserInfoType.id:
+                                if (user.Id != null &&
+                                    user.Id.Trim().Length > 0)
+                                {
+                                    members.Add(user.Id.Trim());
+                                }
+                                break;
+                            case Constants.UserInfoType.mail:
+                                if (user.Mail != null &&
+                                    user.Mail.Trim().Length > 0)
+                                {
+                                    members.Add(user.Mail.Trim());
+                                }
+                                break;
+                            case Constants.UserInfoType.userProfileName:
+                                if (user.UserPrincipalName != null &&
+                                    user.UserPrincipalName.Trim().Length > 0)
+                                {
+                                    members.Add(user.UserPrincipalName.Trim());
+                                }
+                                break;
+                        }
                         return true;
                     });
             pageIterator.IterateAsync().GetAwaiter().GetResult();
@@ -489,9 +519,13 @@ namespace Extensions
         /// of a specified Group.
         /// </summary>
         /// <param name="groupId">The ID (GUID) of the target group.</param>
+        /// <param name="userInfoType">The type of user info to return
+        /// i.e. "id", "mail" or "userProfileName".  Default is "id".</param>
         /// <returns>A list of strings representing the IDs of owner 
         /// users.</returns>
-        public static List<string> GetOwners(string groupId)
+        public static List<string> GetOwners(
+            string groupId,
+            Constants.UserInfoType userInfoType = Constants.UserInfoType.id)
         {
             //Create the aggregation container.
             List<string> owners = new List<string>();
@@ -500,7 +534,10 @@ namespace Extensions
             var usersPage = ActiveAuth.GraphClient.Groups[groupId]
                 .Owners.GraphUser.GetAsync(C =>
                 {
-                    C.QueryParameters.Select = new string[] { "id" };
+                    C.QueryParameters.Select = new string[]
+                    {
+                        userInfoType.ToString()
+                    };
                 }).GetAwaiter().GetResult();
             if (usersPage.Value.Count == 0)
             {
@@ -512,7 +549,30 @@ namespace Extensions
                     usersPage,
                     (user) =>
                     {
-                        owners.Add(user.Id);
+                        switch (userInfoType)
+                        {
+                            case Constants.UserInfoType.id:
+                                if (user.Id != null &&
+                                    user.Id.Trim().Length > 0)
+                                {
+                                    owners.Add(user.Id.Trim());
+                                }
+                                break;
+                            case Constants.UserInfoType.mail:
+                                if (user.Mail != null &&
+                                    user.Mail.Trim().Length > 0)
+                                {
+                                    owners.Add(user.Mail.Trim());
+                                }
+                                break;
+                            case Constants.UserInfoType.userProfileName:
+                                if (user.UserPrincipalName != null &&
+                                    user.UserPrincipalName.Trim().Length > 0)
+                                {
+                                    owners.Add(user.UserPrincipalName.Trim());
+                                }
+                                break;
+                        }
                         return true;
                     });
             pageIterator.IterateAsync().GetAwaiter().GetResult();


### PR DESCRIPTION
-Add Constants.UserInfoType
-Expand Graph.GetMembers() to return more than just "id" by adding "mail" and "userPrincipalName". -Expand Graph.GetOwners() to return more than just "id" by adding "mail" and "userPrincipalName".