### PR TITLE
6.11.800

### DIFF
--- a/Classes/System.Diagnostics.StackTrace.cs
+++ b/Classes/System.Diagnostics.StackTrace.cs
@@ -1,0 +1,71 @@
+﻿/// <summary>
+/// Author: Cornelius J. van Dyk blog.cjvandyk.com @cjvandyk
+/// This code is provided under GNU GPL 3.0 and is a copyrighted work of the
+/// author and contributors.  Please see:
+/// https://github.com/cjvandyk/Extensions/blob/main/LICENSE
+/// </summary>
+
+using System;
+using static Extensions.Core;
+
+namespace Extensions
+{
+    /// <summary>
+    /// Extensions for the System.Diagnostics.StackTrace class.
+    /// </summary>
+    [Serializable]
+    public static partial class StackTraceExtensions
+    {
+        #region Parentage
+        /// <summary>
+        /// A method to return the calling method's name.  Two other methods
+        /// exist in the Parentage group i.e. GrandParent() and
+        /// GreatGrandParent().  If Generations of callers further back are
+        /// needed, this method can be called with the specific number of
+        /// generations to traverse up the calling tree.  If the value of the
+        /// generations exceed the number of callers in the StackTrace calling
+        /// tree, then null will be returned.
+        /// </summary>
+        /// <param name="stackTrace">This instance of the StackTrace.</param>
+        /// <param name="generations">The number of generations to traverse
+        /// back up the stack.  Default is 1.</param>
+        /// <returns>The name of the calling method x generations ago.</returns>
+        public static string Parent(
+            this System.Diagnostics.StackTrace stackTrace, 
+            int generations = 1)
+        {
+            ValidateNoNulls(stackTrace, generations);
+            try
+            {
+                return stackTrace.GetFrame(generations).GetMethod().Name;
+            }
+            catch (Exception ex)
+            {
+                Err(ex.ToString());
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// A method to return the calling method's
+        ///                        calling method's name.
+        /// </summary>
+        /// <returns>The name of the calling method 2 generations ago.</returns>
+        public static string GrandParent()
+        {
+            return Parent(new System.Diagnostics.StackTrace(), 2);
+        }
+
+        /// <summary>
+        /// A method to return the calling method's
+        ///                        calling method's
+        ///                        calling method's name.
+        /// </summary>
+        /// <returns>The name of the calling method 3 generations ago.</returns>
+        public static string GreatGrandParent()
+        {
+            return Parent(new System.Diagnostics.StackTrace(), 3);
+        }
+        #endregion Parentage
+    }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.10.800</VersionPrefix>
+    <VersionPrefix>6.11.800</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Company>Cornelius J. van Dyk</Company>
     <Copyright>Copyright © 2009-2024</Copyright>

--- a/Extensions.csproj
+++ b/Extensions.csproj
@@ -259,7 +259,7 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.59.0" />
     <PackageReference Include="Microsoft.SharePointOnline.CSOM" Version="16.1.24614.12000" />
     <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="TenantConfig.json">

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -389,32 +389,32 @@
 
 ### **6.0.800 (2024-02-26)**<br>
 	- Rearchitected and Optimized.<br>
-	- Rebranded the `Extensions` set of NuGet packages as `GCCHigh.Extensions`.
+	- Rebranded the `Extensions` set of NuGet packages as `GCCHigh.Extensions`.<br>
 
 ### **6.1.800 (2024-02-27)**<br>
-	- Optimized tenant initialization logic in Core.
-	- Added the `getFile` option to `Graph.GetDriveItem()` to allow for retrieval of the underlying binary file.
-	- Added the `TargetTenantConfig` to Identity for initialization optimization.
+	- Optimized tenant initialization logic in Core.<br>
+	- Added the `getFile` option to `Graph.GetDriveItem()` to allow for retrieval of the underlying binary file.<br>
+	- Added the `TargetTenantConfig` to Identity for initialization optimization.<br>
 
 ### **6.2.800 (2024-02-27)**<br>
-	- Optimized logic.
+	- Optimized logic.<br>
 
 ### **6.3.800 (2024-02-27)**<br>
-	- Added CSOM compatibility.
+	- Added CSOM compatibility.<br>
 
 ### **6.5.800 (2024-02-27)**<br>
-	- Added `UserMembershipType` type to Constants.
-	- Added `.GetSiteOwners()` to Graph.
-	- Added `.GetSiteMemers()` to Graph.
-	- Added `.GetSiteUsers()` to Graph.
-	- Fixed `Scopes` in Identity.
+	- Added `UserMembershipType` type to Constants.<br>
+	- Added `.GetSiteOwners()` to Graph.<br>
+	- Added `.GetSiteMemers()` to Graph.<br>
+	- Added `.GetSiteUsers()` to Graph.<br>
+	- Fixed `Scopes` in Identity.<br>
 
 ### **6.6.800 (2024-02-27)**<br>
-	- Changed `.GetHttpClient()` from internal to public.
-	- Made `TryAdd()` on `List<>` and `Dictionary<>` in core internal.
+	- Changed `.GetHttpClient()` from internal to public.<br>
+	- Made `TryAdd()` on `List<>` and `Dictionary<>` in core internal.<br>
 
 ### **6.7.800 (2024-02-28)**<br>
-	- Added handler for sites that don't exist to `.GetSiteId()` in Graph.
+	- Added handler for sites that don't exist to `.GetSiteId()` in Graph.<br>
 
 ### **6.8.800 (2024-02-28)**<br>
 	- Add generic object to `DataContractSerializer` in `State.Load()` and `State.Save()`.<br>
@@ -423,4 +423,13 @@
 	- Add generic object to `DataContractSerializer` in `State.Load()` and `State.Save()`.<br>
 
 ### **6.10.800 (2024-02-29)**<br>
-	- Added the `Core.GetHttpClient()` relay method.
+	- Added the `Core.GetHttpClient()` relay method.<br>
+
+### **6.11.800 (2024-03-02)**<br>
+	- Added a `RUNNING_IN_AZURE` switch to `.GetRunFolder()` method.<br>
+	- Added calling method appendage to `Logit.Log()` to append the name of<br>
+	  the method from which the logging statement was made, to the back of<br>
+	  the message being logged to allow for better trace debugging.<br>
+	- Added the `StackTraceExtensions` class which adds the `.Parent()`,<br>
+	  `.GrandParent()` and `.GreatGrandParent()` methods for getting<br>
+	  parentage method names up the calling stack.<br>


### PR DESCRIPTION
-Added a `RUNNING_IN_AZURE` switch to `.GetRunFolder()` method.
-Added calling method appendage to `Logit.Log()` to append the name of the method from which the logging statement was made, to the back of the message being logged to allow for better trace debugging.
-Added the `StackTraceExtensions` class which adds the `.Parent()`, `.GrandParent()` and `.GreatGrandParent()` methods for getting parentage method names up the calling stack.
