### PR TITLE
6.15.800

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>6.14.800</VersionPrefix>
+    <VersionPrefix>6.15.800</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Company>Cornelius J. van Dyk</Company>
     <Copyright>Copyright © 2009-2024</Copyright>

--- a/Identity/TenantConfig.cs
+++ b/Identity/TenantConfig.cs
@@ -286,15 +286,25 @@ namespace Extensions
                 Settings.Add("TenantString", TenantString);
                 if (Environment.UserInteractive)
                 {
-                    Logit.Inf($"Loading config from [" +
-                        $"{GetRunFolder()}\\{GetConfigFileName()}].");
+                    Core.SetEnv("RUNNING_IN_AZURE", "False");
+                    if (AuthMan.TargetTenantConfig != null)
+                    {
+                        Logit.Inf($"Loading config from [" +
+                            $"{GetRunFolder()}\\{GetConfigFileName()}].");
+                    }
                     Settings = LoadJSON($"{GetRunFolder()}" + 
                         $"\\{GetConfigFileName()}");
-                    Logit.Inf($"Config loaded.\nLoading labels from [" +
-                        $"{GetRunFolder()}\\{GetLabelsFileName()}].");
+                    if (AuthMan.TargetTenantConfig != null)
+                    {
+                        Logit.Inf($"Config loaded.\nLoading labels from [" +
+                            $"{GetRunFolder()}\\{GetLabelsFileName()}].");
+                    }
                     Labels = LoadJSON($"{GetRunFolder()}" +
                         $"\\{GetLabelsFileName()}");
-                    Logit.Inf("Labels loaded.");
+                    if (AuthMan.TargetTenantConfig != null)
+                    {
+                        Logit.Inf("Labels loaded.");
+                    }
                 }
                 else
                 {

--- a/Logit/Logit.cs
+++ b/Logit/Logit.cs
@@ -380,6 +380,10 @@ namespace System
             ConsoleColor foreground,
             ConsoleColor background = ConsoleColor.Black)
         {
+            if (Extensions.Identity.AuthMan.TargetTenantConfig != null)
+            {
+                return;
+            }
             Log(message,
                 0,
                 MessageType.Information,
@@ -418,6 +422,10 @@ namespace System
             //Logging code may NEVER terminate its parent through exceptions.
             try
             {
+                if (Extensions.Identity.AuthMan.TargetTenantConfig != null)
+                {
+                    return;
+                }
                 //Append the caller method to the back of the message.
                 var stackTrace = new System.Diagnostics.StackTrace();
                 //Iterate the stack trace frames.
@@ -703,6 +711,10 @@ namespace System
             int eventId = 0,
             Instance instance = null)
         {
+            if (Extensions.Identity.AuthMan.TargetTenantConfig != null)
+            {
+                return;
+            }
             if (instance == null)
             {
                 instance = ActiveLogitInstance;
@@ -721,6 +733,10 @@ namespace System
             int eventId = 0,
             Instance instance = null)
         {
+            if (Extensions.Identity.AuthMan.TargetTenantConfig != null)
+            {
+                return;
+            }
             if (instance == null)
             {
                 instance = ActiveLogitInstance;
@@ -739,6 +755,10 @@ namespace System
             int eventId = 0,
             Instance instance = null)
         {
+            if (Extensions.Identity.AuthMan.TargetTenantConfig != null)
+            {
+                return;
+            }
             if (instance == null)
             {
                 instance = ActiveLogitInstance;
@@ -757,6 +777,10 @@ namespace System
             int eventId = 0,
             Instance instance = null)
         {
+            if (Extensions.Identity.AuthMan.TargetTenantConfig == null)
+            {
+                return;
+            }
             if (instance == null)
             {
                 instance = ActiveLogitInstance;

--- a/State/System.Object.cs
+++ b/State/System.Object.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text.Json;
 
 namespace Extensions
 {
@@ -53,7 +54,6 @@ namespace Extensions
                 }
 #endif
                 DataContractSerializer serializer = null;
-                LoadSaveContainer lsc = null;
                 lock (lockManager)
                 {
                     using (System.IO.Stream fileStream =
@@ -63,9 +63,9 @@ namespace Extensions
                     {
                         serializer = new DataContractSerializer(
                             obj.GetType(),
-                            new Type[] { typeof(LoadSaveContainer), obj.GetType() });
-                        lsc = (LoadSaveContainer)serializer.ReadObject(fileStream);
-                        return (T)lsc.Value;
+                            new Type[] { obj.GetType() });
+                        string str = (string)serializer.ReadObject(fileStream);
+                        return JsonSerializer.Deserialize<T>(str);
                     }
                 }
             }
@@ -103,8 +103,6 @@ namespace Extensions
                     return BlackCheetah.ObjectExtensions.Save(obj, filePath);
                 }
 #endif
-                LoadSaveContainer loadSaveContainer = new LoadSaveContainer();
-                loadSaveContainer.Value = obj;
                 lock (lockManager)
                 {
                     using (System.IO.Stream fileStream =
@@ -114,8 +112,9 @@ namespace Extensions
                     {
                         var serializer = new DataContractSerializer(
                             obj.GetType(),
-                            new Type[] { typeof(LoadSaveContainer), obj.GetType() });
-                        serializer.WriteObject(fileStream, loadSaveContainer);
+                            new Type[] { obj.GetType() });
+                        string str = JsonSerializer.Serialize(obj);
+                        serializer.WriteObject(fileStream, str);
                         fileStream.Flush();
                     }
                     return true;

--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -639,3 +639,8 @@
 	- Added `.SetSCA()` to `AuthMan`.<br>
 	- Added `.SetSiteUser()` to `AuthMan`.<br>
 	- Added `CacheType` type to `Constants`.<br>
+
+### **6.15.800 (2024-05-02)**<br>
+	- Added validation that `TargetTenantConfig` is valid to avoid endless initialization loop.<br>
+	- Flagged internal `.GetUsers()` and `.GetUsersPages()` methods as `Obsolete`.<br>
+	- Optimized `.Save()` and `.Load()` methods to eliminate `LoadSaveContainer`.<br>


### PR DESCRIPTION
-Added validation that `TargetTenantConfig` is valid to avoid endless initialization loop. 
-Flagged internal `.GetUsers()` and `.GetUsersPages()` methods as `Obsolete`. 
-Optimized `.Save()` and `.Load()` methods to eliminate `LoadSaveContainer`.